### PR TITLE
Added context passing for possibly blocking requests

### DIFF
--- a/sources/network/dns.go
+++ b/sources/network/dns.go
@@ -57,7 +57,7 @@ func (bc *DNSSource) Get(ctx context.Context, itemContext string, query string) 
 	var ips []string
 	var ipsInterface []interface{}
 
-	ips, err = net.LookupHost(query)
+	ips, err = net.DefaultResolver.LookupHost(ctx, query)
 
 	for _, ip := range ips {
 		// Link this to a "global" IP object

--- a/sources/network/socket.go
+++ b/sources/network/socket.go
@@ -135,7 +135,7 @@ func (s *SocketSource) Search(ctx context.Context, itemContext string, query str
 
 	if ip := net.ParseIP(host); ip == nil {
 		// If not an IP, try to convert to an IP (or a list of IPs)
-		ips, err = net.LookupIP(host)
+		ips, err = net.DefaultResolver.LookupIP(ctx, "ip", host)
 
 		if err != nil {
 			return []*sdp.Item{}, &sdp.ItemRequestError{


### PR DESCRIPTION
We were doing DNS lookups without supplying a context meaning that they could hang forever