### PR TITLE
Make health check port an optional thing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,17 +147,13 @@ var rootCmd = &cobra.Command{
 		go func() {
 			defer sentry.Recover()
 
-			log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", healthCheckPort), nil))
-		}()
+			err := http.ListenAndServe(fmt.Sprintf(":%v", healthCheckPort), nil)
 
-		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
 				"port": healthCheckPort,
 				"path": healthCheckPath,
 			}).Error("Could not start HTTP server for /healthz health checks")
-
-			os.Exit(1)
-		}
+		}()
 
 		err = e.Start()
 		if err != nil {


### PR DESCRIPTION
if it fails to start and is required, the infrastructure will tear down the process anyways and we have a chance to still submit tracing info