### PR TITLE
Removed link from entity -> network

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nats-io/nkeys"
 	"github.com/overmindtech/discovery"
 	"github.com/overmindtech/sdp-go/auth"
+	"github.com/overmindtech/stdlib-source/sources/internet"
 	"github.com/overmindtech/stdlib-source/sources/network"
 	"github.com/overmindtech/stdlib-source/sources/test"
 	"github.com/spf13/cobra"
@@ -131,7 +132,7 @@ var rootCmd = &cobra.Command{
 		e.AddSources(sources...)
 
 		// Add the "internet" (RDAP) sources
-		// e.AddSources(internet.NewSources()...)
+		e.AddSources(internet.NewSources()...)
 
 		// Start HTTP server for status
 		healthCheckPort := viper.GetInt("health-check-port")

--- a/sources/internet/entity.go
+++ b/sources/internet/entity.go
@@ -169,25 +169,9 @@ func (s *EntitySource) runEntityRequest(query string, server *url.URL, scope str
 	// Link to related entities
 	item.LinkedItemQueries = extractEntityLinks(entity.Entities)
 
-	// Link to related networks
-	for _, network := range entity.Networks {
-		// +overmind:link rdap-ip-network
-		item.LinkedItemQueries = append(item.LinkedItemQueries, &sdp.LinkedItemQuery{
-			Query: &sdp.Query{
-				Type:   "rdap-ip-network",
-				Method: sdp.QueryMethod_SEARCH,
-				Query:  network.StartAddress,
-				Scope:  scope,
-			},
-			BlastPropagation: &sdp.BlastPropagation{
-				// The network won't affect the entity
-				In: false,
-				// The entity could maybe affect the network? Change this if it
-				// causes issues
-				Out: true,
-			},
-		})
-	}
+	// Don't link to related networks as there are entities with hundreds of
+	// networks and there isn't a reasonable use case that would involve
+	// traversing these
 
 	// Link to related ASNs
 	for _, autnum := range entity.Autnums {


### PR DESCRIPTION
So last night I ran stdlib in dogfood for the first time and got some weird behaviour. There were some things missing, but some were working. However I ran a deep query against the datadog website and hot hundreds of results due to the following set of relationships:

http -> dns -> ip -> RDAP Network -> entity(company) -> entity(parent)

Then this parent entity has hundreds of networks, which then causes hundreds of entity requests to get the entities that own those networks, etc. SO we ended up with a pretty big graph.

At that point one of the nodes in the cluster fell over so I want to bed.

The plan with this is to merge this and try again, it should stop things from running away. Once we have this in, run it again in dogfood and see if we can find more bugs

Fixes #185 