### PR TITLE
Strip all trailing dots for DNS

### DIFF
--- a/sources/internet/domain.go
+++ b/sources/internet/domain.go
@@ -64,6 +64,9 @@ func (s *DomainSource) List(ctx context.Context, scope string, ignoreCache bool)
 // input should be something like "www.google.com". This will first search for
 // "www.google.com", then "google.com", then "com"
 func (s *DomainSource) Search(ctx context.Context, scope string, query string, ignoreCache bool) ([]*sdp.Item, error) {
+	// Strip the trailing dot if it exists
+	query = strings.TrimSuffix(query, ".")
+
 	hit, ck, items, sdpErr := s.Cache.Lookup(ctx, s.Name(), sdp.QueryMethod_SEARCH, scope, s.Type(), query, ignoreCache)
 
 	if sdpErr != nil {

--- a/sources/internet/domain_test.go
+++ b/sources/internet/domain_test.go
@@ -14,7 +14,6 @@ func TestDomainSourceGet(t *testing.T) {
 	}
 
 	t.Run("without a dot", func(t *testing.T) {
-		t.Parallel()
 		items, err := src.Search(context.Background(), "global", "reddit.map.fastly.net", false)
 
 		if err != nil {
@@ -35,7 +34,6 @@ func TestDomainSourceGet(t *testing.T) {
 	})
 
 	t.Run("with a dot", func(t *testing.T) {
-		t.Parallel()
 		items, err := src.Search(context.Background(), "global", "reddit.map.fastly.net.", false)
 
 		if err != nil {

--- a/sources/internet/domain_test.go
+++ b/sources/internet/domain_test.go
@@ -13,21 +13,45 @@ func TestDomainSourceGet(t *testing.T) {
 		Cache:  sdpcache.NewCache(),
 	}
 
-	items, err := src.Search(context.Background(), "global", "www.google.com", false)
+	t.Run("without a dot", func(t *testing.T) {
+		t.Parallel()
+		items, err := src.Search(context.Background(), "global", "reddit.map.fastly.net", false)
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if len(items) != 1 {
-		t.Fatal("Expected 1 item")
-	}
+		if len(items) != 1 {
+			t.Fatal("Expected 1 item")
+		}
 
-	item := items[0]
+		item := items[0]
 
-	err = item.Validate()
+		err = item.Validate()
 
-	if err != nil {
-		t.Error(err)
-	}
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("with a dot", func(t *testing.T) {
+		t.Parallel()
+		items, err := src.Search(context.Background(), "global", "reddit.map.fastly.net.", false)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(items) != 1 {
+			t.Fatal("Expected 1 item")
+		}
+
+		item := items[0]
+
+		err = item.Validate()
+
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }

--- a/sources/internet/main_test.go
+++ b/sources/internet/main_test.go
@@ -1,6 +1,7 @@
 package internet
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/openrdap/rdap"
@@ -9,6 +10,7 @@ import (
 
 func testRdapClient(t *testing.T) *rdap.Client {
 	return &rdap.Client{
+		HTTP: http.DefaultClient,
 		Bootstrap: &bootstrap.Client{
 			Verbose: func(text string) {
 				t.Log(text)


### PR DESCRIPTION
It's *technically* correct, but also confusing since very few people know that these exist and so I'm just going to strip them out