### PR TITLE
Refactor config and improve local dev story

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,51 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+args_bin = ["start"]
+bin = "./tmp/main"
+cmd = "go build -o ./tmp/main main.go"
+delay = 1000
+exclude_dir = ["assets", "build", "tmp", "vendor", "test", "testdata"]
+exclude_file = ["server/admin/assets/dist.css"]
+exclude_regex = [
+  "_test\\.go",
+  "_templ\\.go",
+  "\\.sql\\.go",
+  ".*models/(models|copyfrom|db).go",
+]
+exclude_unchanged = false
+follow_symlink = false
+full_bin = "dlv exec --accept-multiclient --continue --log --headless --listen :9089 --api-version 2 ./tmp/main --"
+include_dir = []
+include_ext = ["go", "tpl", "tmpl", "templ", "html", "sql", "css", "md"]
+include_file = ["sqlc.yaml"]
+kill_delay = "0s"
+log = "build-errors.log"
+poll = false
+poll_interval = 0
+post_cmd = []
+pre_cmd = []
+rerun = false
+rerun_delay = 500
+send_interrupt = false
+stop_on_error = true
+
+[color]
+app = ""
+build = "yellow"
+main = "magenta"
+runner = "green"
+watcher = "cyan"
+
+[log]
+main_only = false
+time = false
+
+[misc]
+clean_on_exit = false
+
+[screen]
+clear_on_rebuild = false
+keep_scroll = true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,5 +34,8 @@
 		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	// Set up environment variables in the remote container.
-	"remoteEnv": {}
+	"remoteEnv": {
+		"LOG": "trace",
+		"NATS_SERVERS": "nats://messages.app.overmind.tech"
+	}
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -4,4 +4,4 @@ eval $(go env)
 
 mkdir -p ~/.local/bin/ && curl -o ~/.local/bin/docgen https://github.com/overmindtech/docgen/releases/latest/download/docgen-${GOARCH} && chmod +x ~/.local/bin/docgen
 
-go mod vendor
+go install github.com/cosmtrek/air@latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ output
 vendor
 Gopkg.lock
 build/compiled
+/tmp/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,15 +5,19 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Package",
+            "name": "Launch stdlib-source",
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}/main.go",
-            "env": {
-                "NATS_SERVERS": "nats://nats.overmind-demo.youcan.dance",
-                "LOG": "trace",
-            }
+            "program": "${workspaceFolder}/main.go"
+        },
+        {
+            "name": "Attach to `air`",
+            "type": "go",
+            "host": "localhost",
+            "mode": "remote",
+            "port": 9089,
+            "request": "attach"
         },
     ]
 }

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ All configuration options can be provided via the command line or as environment
 | `NATS_NAME_PREFIX`| `--nats-name-prefix` | ✅ | A name label prefix. Sources should append a dot and their hostname .{hostname} to this, then set this is the NATS connection name which will be sent to the server on CONNECT to identify the client |
 | `NATS_JWT` | `--nats-jwt` | ✅ | The JWT token that should be used to authenticate to NATS, provided in raw format e.g. `eyJ0eXAiOiJKV1Q{...}` |
 | `NATS_NKEY_SEED` | `--nats-nkey-seed` | ✅ | The NKey seed which corresponds to the NATS JWT e.g. `SUAFK6QUC{...}` |
-| `MAX-PARALLEL`| `--max-parallel` | ✅ | Max number of requests to run in parallel |
-| `YOUR_CUSTOM_FLAG`| `--your-custom-flag` |   | Configuration that you add should be documented here |
+| `MAX_PARALLEL`| `--max-parallel` | ✅ | Max number of requests to run in parallel |
 
 ### `srcman` config
 
@@ -32,11 +31,9 @@ spec:
   manager: manager-source
 ```
 
-**NOTE:** Remove the above boilerplate once you know what configuration will be required.
-
 ### Health Check
 
-The source hosts a health check on `:8080/healthz` which will return an error if NATS is not connected. An example Kubernetes readiness probe is:
+The source hosts a health check on `:8089/healthz` which will return an error if NATS is not connected. An example Kubernetes readiness probe is:
 
 ```yaml
 readinessProbe:
@@ -55,6 +52,12 @@ The source CLI can be interacted with locally by running:
 go run main.go --help
 ```
 
+To get automatic recompiles and reloading on code changes, use:
+
+```
+air
+```
+
 ### Testing
 
 Tests in this package can be run using:
@@ -66,4 +69,3 @@ go test ./...
 ### Packaging
 
 Docker images can be created manually using `docker build`, but GitHub actions also exist that are able to create, tag and push images. Images will be build for the `main` branch, and also for any commits tagged with a version such as `v1.2.0`
-

--- a/sources/main.go
+++ b/sources/main.go
@@ -1,0 +1,45 @@
+package sources
+
+import (
+	"github.com/overmindtech/discovery"
+	"github.com/overmindtech/sdp-go/auth"
+	"github.com/overmindtech/stdlib-source/sources/internet"
+	"github.com/overmindtech/stdlib-source/sources/network"
+	"github.com/overmindtech/stdlib-source/sources/test"
+	log "github.com/sirupsen/logrus"
+)
+
+func InitializeEngine(natsOptions auth.NATSOptions, maxParallel int, reverseDNS bool) (*discovery.Engine, error) {
+	e, err := discovery.NewEngine()
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Fatal("Error initializing Engine")
+	}
+	e.Name = "stdlib-source"
+	e.NATSOptions = &natsOptions
+	e.MaxParallelExecutions = maxParallel
+
+	// Add the base sources
+	sources := []discovery.Source{
+		&network.CertificateSource{},
+		&network.DNSSource{
+			ReverseLookup: reverseDNS,
+		},
+		&network.HTTPSource{},
+		&network.IPSource{},
+		&test.TestDogSource{},
+		&test.TestGroupSource{},
+		&test.TestHobbySource{},
+		&test.TestLocationSource{},
+		&test.TestPersonSource{},
+		&test.TestRegionSource{},
+	}
+
+	e.AddSources(sources...)
+
+	// Add the "internet" (RDAP) sources
+	e.AddSources(internet.NewSources()...)
+
+	return e, nil
+}


### PR DESCRIPTION
This also moves the `InitializeEngine` method to the sources package to avoid pulling in viper and polluting the CLI's viper config when loading stdlib in-process.