### PR TITLE
maint: reduce binary size in docker image

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -20,7 +20,7 @@ COPY sources/ sources/
 
 # Build
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o source main.go
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -o source main.go
 
 FROM alpine:3.20
 WORKDIR /


### PR DESCRIPTION
```
➜  stdlib-source git:(reduce_binary_size) ✗ ls -alh big small
-rwxr-xr-x 1 frame frame 34M Jul  1 15:51 big
-rwxr-xr-x 1 frame frame 25M Jul  1 15:50 small
```
RE https://github.com/overmindtech/deploy/issues/868