### PR TITLE
(maint) run golangci-lint in ci

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Test
         run: go test -v -race ./...
 
+      # get .golangci.yml from github.com/overmindtech/golangci-lint_config
+      - name: Get .golangci.yml from github.com/overmindtech/golangci-lint_configs
+        run: |
+          curl -sfL https://raw.githubusercontent.com/overmindtech/golangci-lint_config/main/.golangci.yml -o .golangci.yml
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.56.1
+          args: --timeout 3m
+          skip-cache: true # the linters require all code generation and dependecies to be present, but the cache implementation completely falls over when there is already existing content. See https://github.com/golangci/golangci-lint-action/issues/23, https://github.com/golangci/golangci-lint-action/issues/863, https://github.com/golangci/golangci-lint-action/issues/984
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-__debug_bin
+__debug_bin*
 .vagrant
 output
 vendor

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ go run main.go --help
 
 To get automatic recompiles and reloading on code changes, use:
 
-```
+```shell
 air
 ```
 

--- a/sources/internet/entity_test.go
+++ b/sources/internet/entity_test.go
@@ -56,8 +56,8 @@ func TestEntitySourceSearch(t *testing.T) {
 		var sdpError *sdp.QueryError
 
 		if ok := errors.As(err, &sdpError); ok {
-			if sdpError.ErrorType != sdp.QueryError_NOTFOUND {
-				t.Errorf("Expected QueryError_NOTFOUND, got %v", sdpError.ErrorType)
+			if sdpError.GetErrorType() != sdp.QueryError_NOTFOUND {
+				t.Errorf("Expected QueryError_NOTFOUND, got %v", sdpError.GetErrorType())
 			}
 		} else {
 			t.Fatalf("Expected QueryError, got %T", err)

--- a/sources/internet/ip_network_test.go
+++ b/sources/internet/ip_network_test.go
@@ -33,8 +33,8 @@ func TestIpNetworkSourceSearch(t *testing.T) {
 		t.Errorf("Expected unique attribute value to be 1.1.1.0 - 1.1.1.0 - 1.1.1.255, got %v", item.UniqueAttributeValue())
 	}
 
-	if len(item.LinkedItemQueries) != 3 {
-		t.Errorf("Expected 3 linked items, got %v", len(item.LinkedItemQueries))
+	if len(item.GetLinkedItemQueries()) != 3 {
+		t.Errorf("Expected 3 linked items, got %v", len(item.GetLinkedItemQueries()))
 	}
 
 	// Then run a get for that same thing and hit the cache

--- a/sources/network/certificate_test.go
+++ b/sources/network/certificate_test.go
@@ -103,7 +103,7 @@ type CertTest struct {
 
 func (c *CertTest) Run(t *testing.T, cert *sdp.Item) {
 	t.Run(fmt.Sprintf("Validating %v", c.Attribute), func(t *testing.T) {
-		if x, err := cert.Attributes.Get(c.Attribute); err == nil {
+		if x, err := cert.GetAttributes().Get(c.Attribute); err == nil {
 			if fmt.Sprint(x) != fmt.Sprint(c.Expected) {
 				t.Errorf("%v mismatch, expected %v, got %v", c.Attribute, c.Expected, x)
 			}

--- a/sources/network/dns_test.go
+++ b/sources/network/dns_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
@@ -42,11 +43,11 @@ func TestSearch(t *testing.T) {
 		var foundV4 bool
 		var foundV6 bool
 		for _, item := range items {
-			for _, q := range item.LinkedItemQueries {
-				if q.Query.Query == "1.1.1.1" {
+			for _, q := range item.GetLinkedItemQueries() {
+				if q.GetQuery().GetQuery() == "1.1.1.1" {
 					foundV4 = true
 				}
-				if q.Query.Query == "2606:4700:4700::1111" {
+				if q.GetQuery().GetQuery() == "2606:4700:4700::1111" {
 					foundV6 = true
 				}
 			}
@@ -74,11 +75,11 @@ func TestSearch(t *testing.T) {
 		var foundV4 bool
 		var foundV6 bool
 		for _, item := range items {
-			for _, q := range item.LinkedItemQueries {
-				if q.Query.Query == "1.1.1.1" {
+			for _, q := range item.GetLinkedItemQueries() {
+				if q.GetQuery().GetQuery() == "1.1.1.1" {
 					foundV4 = true
 				}
-				if q.Query.Query == "2606:4700:4700::1111" {
+				if q.GetQuery().GetQuery() == "2606:4700:4700::1111" {
 					foundV6 = true
 				}
 			}
@@ -101,7 +102,7 @@ func TestDnsGet(t *testing.T) {
 	var conn net.Conn
 	var err error
 
-	// Check that we actually have an inertnet connection, if not there is not
+	// Check that we actually have an internet connection, if not there is not
 	// point running this test
 	conn, err = net.Dial("tcp", "one.one.one.one:443")
 	conn.Close()
@@ -129,11 +130,8 @@ func TestDnsGet(t *testing.T) {
 			t.Error("expected error but got nil")
 		}
 
-		if sdpErr, ok := err.(*sdp.QueryError); ok {
-			if sdpErr.ErrorType != sdp.QueryError_NOTFOUND {
-				t.Errorf("Expected error type to be NOTFOUND, got %v", sdpErr.ErrorType)
-			}
-		} else {
+		var e *sdp.QueryError
+		if !errors.As(err, &e) {
 			t.Errorf("expected error type to be *sdp.QueryError, got %T", err)
 		}
 	})
@@ -145,12 +143,9 @@ func TestDnsGet(t *testing.T) {
 			t.Error("expected error but got nil")
 		}
 
-		if sdpErr, ok := err.(*sdp.QueryError); ok {
-			if sdpErr.ErrorType != sdp.QueryError_NOSCOPE {
-				t.Errorf("Expected error type to be NOSCOPE, got %v", sdpErr.ErrorType)
-			}
-		} else {
-			t.Errorf("expected error type to be *sdp.QueryError, got %t", err)
+		var e *sdp.QueryError
+		if !errors.As(err, &e) {
+			t.Errorf("expected error type to be *sdp.QueryError, got %T", err)
 		}
 	})
 
@@ -163,7 +158,7 @@ func TestDnsGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		target := item.Attributes.AttrStruct.Fields["target"].GetStringValue()
+		target := item.GetAttributes().GetAttrStruct().GetFields()["target"].GetStringValue()
 		if target != "github.com" {
 			t.Errorf("expected target to be github.com, got %v", target)
 		}

--- a/sources/network/http.go
+++ b/sources/network/http.go
@@ -100,7 +100,7 @@ func (s *HTTPSource) Get(ctx context.Context, scope string, query string, ignore
 	// we are only running a HEAD request this is unlikely to be a problem
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, // nolint:gosec // This is fine for a HEAD request
 		},
 	}
 	client := &http.Client{
@@ -225,9 +225,6 @@ func (s *HTTPSource) Get(ctx context.Context, scope string, query string, ignore
 			version = "TLSv1.2"
 		case tls.VersionTLS13:
 			version = "TLSv1.3"
-		//lint:ignore SA1019 We are just *checking* SSLv3, not using it
-		case tls.VersionSSL30:
-			version = "SSLv3"
 		default:
 			version = "unknown"
 		}

--- a/sources/network/http_test.go
+++ b/sources/network/http_test.go
@@ -26,12 +26,18 @@ func NewTestServer() (*TestHTTPServer, error) {
 
 	sm.Handle("/404", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(404)
-		w.Write([]byte("not found innit"))
+		_, err := w.Write([]byte("not found innit"))
+		if err != nil {
+			return
+		}
 	}))
 
 	sm.Handle("/500", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
-		w.Write([]byte("yeah nah innit"))
+		_, err := w.Write([]byte("yeah nah innit"))
+		if err != nil {
+			return
+		}
 	}))
 
 	sm.Handle("/301", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -59,12 +65,12 @@ func TestHTTPGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if i, err := item.Attributes.Get("tls"); err == nil {
+		if i, err := item.GetAttributes().Get("tls"); err == nil {
 			if tlsMap, ok := i.(map[string]interface{}); ok {
 				certName := fmt.Sprint(tlsMap["certificate"])
 
-				if matched, _ := regexp.MatchString(`www.google.com \(SHA-1: `, certName); !matched {
-					t.Errorf("expected cert name to match www.google.com (SHA-1: , got: %v", certName)
+				if matched, _ := regexp.MatchString(`www.google.com \(SHA-256: `, certName); !matched {
+					t.Errorf("expected cert name to match www.google.com (SHA-256: , got: %v", certName)
 				}
 			} else {
 				t.Error("expected tls to be map[string]interface{}")
@@ -85,13 +91,13 @@ func TestHTTPGet(t *testing.T) {
 
 		var dnsFound bool
 
-		for _, link := range item.LinkedItemQueries {
-			switch link.Query.Type {
+		for _, link := range item.GetLinkedItemQueries() {
+			switch link.GetQuery().GetType() {
 			case "dns":
 				dnsFound = true
 
-				if link.Query.Query != "www.google.com" {
-					t.Errorf("expected dns query to be www.google.com, got %v", link.Query)
+				if link.GetQuery().GetQuery() != "www.google.com" {
+					t.Errorf("expected dns query to be www.google.com, got %v", link.GetQuery())
 				}
 			}
 		}
@@ -112,13 +118,13 @@ func TestHTTPGet(t *testing.T) {
 
 		var ipFound bool
 
-		for _, link := range item.LinkedItemQueries {
-			switch link.Query.Type {
+		for _, link := range item.GetLinkedItemQueries() {
+			switch link.GetQuery().GetType() {
 			case "ip":
 				ipFound = true
 
-				if link.Query.Query != "1.1.1.1" {
-					t.Errorf("expected dns query to be 1.1.1.1, got %v", link.Query)
+				if link.GetQuery().GetQuery() != "1.1.1.1" {
+					t.Errorf("expected dns query to be 1.1.1.1, got %v", link.GetQuery())
 				}
 			}
 		}
@@ -147,7 +153,7 @@ func TestHTTPGet(t *testing.T) {
 
 		var status interface{}
 
-		status, err = item.Attributes.Get("status")
+		status, err = item.GetAttributes().Get("status")
 
 		if err != nil {
 			t.Fatal(err)
@@ -187,7 +193,7 @@ func TestHTTPGet(t *testing.T) {
 
 		var status interface{}
 
-		status, err = item.Attributes.Get("status")
+		status, err = item.GetAttributes().Get("status")
 
 		if err != nil {
 			t.Fatal(err)
@@ -217,7 +223,7 @@ func TestHTTPGet(t *testing.T) {
 
 		var status interface{}
 
-		status, err = item.Attributes.Get("status")
+		status, err = item.GetAttributes().Get("status")
 
 		if err != nil {
 			t.Fatal(err)
@@ -227,7 +233,7 @@ func TestHTTPGet(t *testing.T) {
 			t.Errorf("expected status to be 301, got: %v", status)
 		}
 
-		if len(item.LinkedItemQueries) == 0 {
+		if len(item.GetLinkedItemQueries()) == 0 {
 			t.Error("expected a linked item to redirected location, got none")
 		}
 
@@ -241,7 +247,7 @@ func TestHTTPGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = item.Attributes.Get("tls")
+		_, err = item.GetAttributes().Get("tls")
 
 		if err == nil {
 			t.Error("Expected to not find TLS info")

--- a/sources/network/ip_test.go
+++ b/sources/network/ip_test.go
@@ -19,9 +19,9 @@ func TestIPGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if private, err := item.Attributes.Get("private"); err == nil {
+		if private, err := item.GetAttributes().Get("private"); err == nil {
 			if private != false {
-				t.Error("Expected itemattributes.private to be false")
+				t.Error("Expected itemAttributes.private to be false")
 			}
 		} else {
 			t.Error("could not find 'private' attribute")
@@ -37,9 +37,9 @@ func TestIPGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if private, err := item.Attributes.Get("private"); err == nil {
+		if private, err := item.GetAttributes().Get("private"); err == nil {
 			if private != false {
-				t.Error("Expected itemattributes.private to be false")
+				t.Error("Expected itemAttributes.private to be false")
 			}
 		} else {
 			t.Error("could not find 'private' attribute")
@@ -81,11 +81,11 @@ func TestIPGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if item.Scope != "some.computer" {
-				t.Errorf("expected scope to be some.computer, got %v", item.Scope)
+			if item.GetScope() != "some.computer" {
+				t.Errorf("expected scope to be some.computer, got %v", item.GetScope())
 			}
 
-			if llu, err := item.Attributes.Get("linkLocalUnicast"); err != nil || llu == false {
+			if llu, err := item.GetAttributes().Get("linkLocalUnicast"); err != nil || llu == false {
 				t.Errorf("expected linkLocalUnicast to be false, got %v", llu)
 			}
 
@@ -101,7 +101,7 @@ func TestIPGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if p, err := item.Attributes.Get("private"); err != nil || p == false {
+			if p, err := item.GetAttributes().Get("private"); err != nil || p == false {
 				t.Errorf("expected p to be true, got %v", p)
 			}
 
@@ -138,11 +138,11 @@ func TestIPGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if item.Scope != "some.computer" {
-				t.Errorf("expected scope to be some.computer, got %v", item.Scope)
+			if item.GetScope() != "some.computer" {
+				t.Errorf("expected scope to be some.computer, got %v", item.GetScope())
 			}
 
-			if loopback, err := item.Attributes.Get("loopback"); err != nil || loopback == false {
+			if loopback, err := item.GetAttributes().Get("loopback"); err != nil || loopback == false {
 				t.Errorf("expected loopback to be false, got %v", loopback)
 			}
 
@@ -171,11 +171,11 @@ func TestIPGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if item.Scope != "some.computer" {
-				t.Errorf("expected scope to be some.computer, got %v", item.Scope)
+			if item.GetScope() != "some.computer" {
+				t.Errorf("expected scope to be some.computer, got %v", item.GetScope())
 			}
 
-			if llu, err := item.Attributes.Get("linkLocalUnicast"); err != nil || llu == false {
+			if llu, err := item.GetAttributes().Get("linkLocalUnicast"); err != nil || llu == false {
 				t.Errorf("expected linkLocalUnicast top be false, got %v", llu)
 			}
 
@@ -191,7 +191,7 @@ func TestIPGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if p, err := item.Attributes.Get("private"); err != nil || p == false {
+			if p, err := item.GetAttributes().Get("private"); err != nil || p == false {
 				t.Errorf("expected p to be true, got %v", p)
 			}
 
@@ -229,11 +229,11 @@ func TestIPGet(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if item.Scope != "some.computer" {
-				t.Errorf("expected scope to be some.computer, got %v", item.Scope)
+			if item.GetScope() != "some.computer" {
+				t.Errorf("expected scope to be some.computer, got %v", item.GetScope())
 			}
 
-			if loopback, err := item.Attributes.Get("loopback"); err != nil || loopback == false {
+			if loopback, err := item.GetAttributes().Get("loopback"); err != nil || loopback == false {
 				t.Errorf("expected loopback to be false, got %v", loopback)
 			}
 
@@ -248,9 +248,9 @@ func TestIPGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if private, err := item.Attributes.Get("private"); err == nil {
+		if private, err := item.GetAttributes().Get("private"); err == nil {
 			if private != false {
-				t.Error("Expected itemattributes.private to be false")
+				t.Error("Expected itemAttributes.private to be false")
 			}
 		} else {
 			t.Error("could not find 'private' attribute")


### PR DESCRIPTION
It should only flag lint errors going forward, on changes in the PR. 
until we can fix the existing issues. https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#only-new-issues